### PR TITLE
Editor display CSS update

### DIFF
--- a/scribbler/static/scribbler/less/scribbler.less
+++ b/scribbler/static/scribbler/less/scribbler.less
@@ -149,10 +149,6 @@
     width: 100%;
     height: 0;
 
-    .CodeMirror {
-        background-color: #FFFFFF;
-    }
-
     .controls {
         font-family: Helvetica, Arial, sans-serif;
         .box-shadow(0 -5px 6px rgba(0, 0, 0, .04));
@@ -222,6 +218,8 @@
 /* Codemirror customization styles
 ==================================== */
 .CodeMirror {
+    background-color: #FFFFFF;
+    
     .activeline {
         background: @red !important;
     }


### PR DESCRIPTION
Quick CSS change to make sure the content isnt display through the editor

As a side note, would be nice if the content div would resize along with the appearing editor (reduce the height so the editor does not overlay lengthy content)
