### PR TITLE
use try and except for django pre and post 1.9 in form mixin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 
 env:
   - TOXENV=py27-1.8.X,py33-1.8.X,py34-1.8.X
+  - TOXENV=py27-1.9.X,py34-1.9.X
   - TOXENV=coverage
   - TOXENV=docs
   - TOXENV=qunit

--- a/scribbler/forms.py
+++ b/scribbler/forms.py
@@ -33,10 +33,10 @@ class ScribbleFormMixin(object):
                     parser = DebugParser(lexer.tokenize())
                     parser.parse()
             except Exception as e:
-                    self.exc_info = sys.exc_info()
-                    if not hasattr(self.exc_info[1], 'django_template_source'):
-                        self.exc_info[1].django_template_source = origin, (0, 0)
-                    raise forms.ValidationError('Invalid Django Template')
+                self.exc_info = sys.exc_info()
+                if not hasattr(self.exc_info[1], 'django_template_source'):
+                    self.exc_info[1].django_template_source = origin, (0, 0)
+                raise forms.ValidationError('Invalid Django Template')
         return content
 
 

--- a/scribbler/views.py
+++ b/scribbler/views.py
@@ -51,10 +51,17 @@ def preview_scribble(request):
         results['variables'] = get_variables(RequestContext(request, context))
     else:
         if hasattr(form, 'exc_info'):
-            exc_type, exc_value, tb = form.exc_info
-            reporter = ExceptionReporter(request, exc_type, exc_value, tb)
-            reporter.get_template_exception_info()
-            results['error'] = reporter.template_info
+            # Pre Django 1.9
+            try:
+                exc_type, exc_value, tb = form.exc_info
+                reporter = ExceptionReporter(request, exc_type, exc_value, tb)
+                reporter.get_template_exception_info()
+                results['error'] = reporter.template_info
+            # Django >= 1.9: get_template_info() is moved from ExceptionReporter
+            # onto Template. We pass the data it returns from scribbler/forms.py
+            # to here.
+            except ValueError:
+                results['error'] = form.exc_info
         else:
             # Not sure what to do here
             results['error'] = {

--- a/scribbler/views.py
+++ b/scribbler/views.py
@@ -60,7 +60,10 @@ def preview_scribble(request):
             # Django >= 1.9: get_template_info() is moved from ExceptionReporter
             # onto Template. We pass the data it returns from scribbler/forms.py
             # to here.
-            except ValueError:
+            except (ValueError, AttributeError):
+                # ValueError is raised when we pass in all 12 the arguments,
+                # in form.exc_info and AttributeError is raised when
+                # ExceptionReporter.get_template_exception_info() is called.
                 results['error'] = form.exc_info
         else:
             # Not sure what to do here

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py33,py34}-{1.8}.X,coverage,docs,qunit
+envlist = {py27,py33,py34}-{1.8}.X,{py27,py34}-{1.9}.X,coverage,docs,qunit
 
 [testenv]
 passenv = TRAVIS DISPLAY
@@ -9,6 +9,7 @@ basepython =
     py34: python3.4
 deps =
     1.8.X: Django>=1.8,<1.9
+    1.9.X: Django>=1.8,<1.9
     {py27,py33,py34}: Jinja2
     selenium
 whitelist_externals = make
@@ -23,7 +24,7 @@ commands = make fetch-static-libs build-css build-js
            coverage run runtests.py
            coverage report -m --fail-under 80
 deps = coverage>=3.7.
-       Django>=1.8,<1.9
+       Django>=1.8,<1.10
        Jinja2
        selenium
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ basepython =
     py34: python3.4
 deps =
     1.8.X: Django>=1.8,<1.9
-    1.9.X: Django>=1.8,<1.9
+    1.9.X: Django>=1.9,<1.10
     {py27,py33,py34}: Jinja2
     selenium
 whitelist_externals = make


### PR DESCRIPTION
#117 
Since `django.template.debug` no longer exists in Django 1.9, we check the Django version. For versions prior to 1.9 we continue to use the previous code with `DebugLexer` and `DebugParser`. For Django 1.9 and greater we use `django.template`'s `Template`.
