### PR TITLE
Disallow scribble previews if the user does not have permission

### DIFF
--- a/scribbler/forms.py
+++ b/scribbler/forms.py
@@ -7,6 +7,7 @@ from django import forms
 from django.db.models import ObjectDoesNotExist, FieldDoesNotExist
 from django.template import StringOrigin
 from django.core.urlresolvers import reverse
+from django.contrib.contenttypes.models import ContentType
 
 from .models import Scribble
 
@@ -71,6 +72,10 @@ class ScribbleForm(forms.ModelForm, ScribbleFormMixin):
     def get_data_prefix(self):
         return self.instance.slug
 
+    def get_preview_url(self):
+        content_type = ContentType.objects.get_for_model(Scribble)
+        return reverse('preview-scribble', args=(content_type.pk,))
+
     def get_save_url(self):
         return self.instance.get_save_url()
 
@@ -120,6 +125,9 @@ class FieldScribbleForm(forms.Form, ScribbleFormMixin):
 
     def get_data_prefix(self):
         return self.prefix
+
+    def get_preview_url(self):
+        return reverse('preview-scribble', args=(self.content_type.pk,))
 
     def get_save_url(self):
         args=(self.content_type.pk, self.instance_pk, self.field_name)

--- a/scribbler/templates/scribbler/edit-form.html
+++ b/scribbler/templates/scribbler/edit-form.html
@@ -1,7 +1,7 @@
 <form class="scribble-form" data-prefix="{{ form.get_data_prefix }}"
 {% if can_edit_scribble or can_add_scribble %}data-save="{{ form.get_save_url }}"{% endif %}
 {% if can_delete_scribble %}data-delete="{{ form.get_delete_url }}"{% endif %}
-action="{% url 'preview-scribble' %}" method="post">{% csrf_token %}
+action="{{ form.get_preview_url }}" method="post">{% csrf_token %}
     <div class="hidden">
         {% for field in form.hidden_fields %}
             {{ field }}

--- a/scribbler/urls.py
+++ b/scribbler/urls.py
@@ -11,7 +11,7 @@ from scribbler import views
 
 
 urlpatterns = (
-    url('^preview/$', views.preview_scribble, name='preview-scribble'),
+    url('^preview/(?P<ct_pk>(\d+))$', views.preview_scribble, name='preview-scribble'),
     url('^create/$', views.create_edit_scribble, name='create-scribble'),
     url('^edit/(?P<scribble_id>(\d+))/$', views.create_edit_scribble, name='edit-scribble'),
     url('^delete/(?P<scribble_id>(\d+))/$', views.delete_scribble, name='delete-scribble'),

--- a/scribbler/views.py
+++ b/scribbler/views.py
@@ -27,12 +27,17 @@ def build_scribble_context(scribble):
 
 
 @require_POST
-def preview_scribble(request):
+def preview_scribble(request, ct_pk):
     "Render scribble content or return error information."
     if not request.user.is_authenticated():
         return HttpResponseForbidden()
-    can_edit = request.user.has_perm('scribbler.change_scribble')
-    can_create = request.user.has_perm('scribbler.add_scribble')
+    content_type = get_object_or_404(ContentType, pk=ct_pk)
+    change_scribble = '{0}.change_{1}'.format(
+        content_type.app_label, content_type.model)
+    add_scribble = '{0}.add_{1}'.format(
+        content_type.app_label, content_type.model)
+    can_edit = request.user.has_perm(change_scribble)
+    can_create = request.user.has_perm(add_scribble)
     if not (can_edit or can_create):
         return HttpResponseForbidden()
     results = {


### PR DESCRIPTION
* The preview-scribble url pattern now takes a ContentType pk
* ScribbleForm and FieldScribbleForm now have a get_preview_url() method, adding the right content_type pk to the url
* The preview_scribble view now constructs the permissions to check based on the ContentType specified

Fixes #48.