### PR TITLE
Help with running a non-release

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,7 @@ To install from PyPi::
 
     pip install django-scribbler
 
+.. note:: If you need to run an unreleased version from the repository, see the `Contributing Guide <http://django-scribbler.readthedocs.org/en/latest/contributing.html>`_ for additional instructions.
 
 Documentation
 -----------------------------------

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -4,6 +4,14 @@ Getting Started
 Below are the basic steps need to get django-scribbler integrated into your
 Django project.
 
+Install Scribbler
+------------------------------------
+
+django-scribbler should be installed using ``pip``::
+
+    $ pip install django-scribbler
+
+.. note:: If you need to run an unreleased version from the repository, see :doc:`contributing` for additional instructions.
 
 Configure Settings
 ------------------------------------


### PR DESCRIPTION
Add a couple of notes in the docs pointing users to the
part of the docs about extra steps needed when running an
unreleased version of django-scribbler.