### PR TITLE
update github project name in setup url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author_email='solutions@caktusgroup.com',
     packages=find_packages(exclude=['example']),
     include_package_data=True,
-    url='https://github.com/caktus/scribbler',
+    url='https://github.com/caktus/django-scribbler',
     license='BSD-2-Clause',
     description=' '.join(__import__('scribbler').__doc__.splitlines()).strip(),
     classifiers=[


### PR DESCRIPTION
s/scribbler/django-scribbler/

It's a trivial PR, but without it the link from PyPI to the repository is broken. Please feel free to just close/squash this change into your next regular README update... :smile: 

Thanks very much for all the code you've shared!!