### PR TITLE
Scribble form would fail with a 500 error if certain characters were present in the form field

### DIFF
--- a/scribbler/forms.py
+++ b/scribbler/forms.py
@@ -17,7 +17,7 @@ class ScribbleFormMixin(object):
     def clean_content(self):
         content = self.cleaned_data.get('content', '')
         if content:
-            origin = StringOrigin(content)
+            origin = StringOrigin(content.encode('utf-8'))
 
             try:
                 from django.template.debug import DebugLexer, DebugParser

--- a/scribbler/tests/test_views.py
+++ b/scribbler/tests/test_views.py
@@ -483,11 +483,11 @@ class UnicodeTestCase(BaseViewTestCase):
         content_type = ContentType.objects.get_for_model(Scribble)
         self.url = reverse('create-scribble')
 
-    def test_curly_quotes(self):
+    def test_unicode_chars_allowed_in_scribble(self):
         data = {
             'slug': 'test',
             'url': '/',
-            'content': '“'
+            'content': '😀Iñtërnâtiônàlizætiøn“”'
         }
         response = self.client.post(self.url, data=data)
         self.assertEqual(response.status_code, 200)

--- a/scribbler/tests/test_views.py
+++ b/scribbler/tests/test_views.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 "Tests for preview/save views."
 from __future__ import unicode_literals
 
@@ -470,3 +472,26 @@ class FunctionalTestCase(StaticLiveServerTestCase, BaseViewTestCase):
         action.send_keys(Keys.F11)
         action.perform()
         self.assertTrue(self.browser.find_element_by_class_name("CodeMirror-fullscreen"))
+
+
+
+class UnicodeTestCase(BaseViewTestCase):
+    "Unicode chars in scribbles."
+
+    def setUp(self):
+        super(UnicodeTestCase, self).setUp()
+        content_type = ContentType.objects.get_for_model(Scribble)
+        self.url = reverse('create-scribble')
+
+    def test_curly_quotes(self):
+        data = {
+            'slug': 'test',
+            'url': '/',
+            'content': '“'
+        }
+        response = self.client.post(self.url, data=data)
+        self.assertEqual(response.status_code, 200)
+        results = json.loads(response.content.decode('utf-8'))
+        self.assertTrue(results['valid'])
+        scribble = Scribble.objects.get(slug=data['slug'], url=data['url'])
+        self.assertEqual(scribble.content, data['content'])


### PR DESCRIPTION
This ensures that the content from the form field is properly encoded before being used as a template.  Previously we'd get an `exceptions.UnicodeEncodeError' object has no attribute 'token'` when trying to save.