### PR TITLE
Adding request context to scribble context

### DIFF
--- a/scribbler/templatetags/scribbler_tags.py
+++ b/scribbler/templatetags/scribbler_tags.py
@@ -71,7 +71,7 @@ class ScribbleNode(template.Node):
                 scribble_template = template.engines['django'].from_string(self.raw)
             else:
                 scribble_template = template.Template(self.raw)
-        scribble_context = build_scribble_context(scribble)
+        scribble_context = build_scribble_context(scribble, context)
         content = scribble_template.render(scribble_context, request)
         wrapper_template = template.loader.get_template('scribbler/scribble-wrapper.html')
         context['scribble'] = scribble
@@ -189,7 +189,7 @@ def scribble_field(context, model_instance, field_name):
         scribble_template = template.engines['django'].from_string(field_value)
     else:
         scribble_template = template.Template(field_value)
-    scribble_context = build_scribble_context(None)
+    scribble_context = build_scribble_context(None, context)
     rendered_content = scribble_template.render(scribble_context, request)
     context['rendered_scribble'] = rendered_content
 

--- a/scribbler/tests/test_templatetags.py
+++ b/scribbler/tests/test_templatetags.py
@@ -185,6 +185,13 @@ class RenderScribbleTestCase(ScribblerDataTestCase):
         self.assertTrue('<form' in result)
         self.assertTrue('with-controls' in result)
 
+    def test_parent_context_available_in_scribble(self):
+        "Parent template context variables are accessible inside scribble content."
+        self.scribble.content = '{{ greeting }}'
+        self.scribble.save()
+        result = self.render_template_tag(slug='"sidebar"', context={'greeting': 'hello'})
+        self.assertIn('hello', result)
+
 
 class RenderScribbleFieldTestCase(ScribblerDataTestCase):
     "Tag to render a model field instance scribble."
@@ -235,3 +242,10 @@ class RenderScribbleFieldTestCase(ScribblerDataTestCase):
         result = self.render_template_tag(self.days_log, 'happenings')
         self.assertTrue('<form' in result)
         self.assertTrue('with-controls' in result)
+
+    def test_parent_context_available_in_scribble_field(self):
+        "Parent template context variables are accessible inside scribble field content."
+        self.days_log.happenings = '{{ greeting }}'
+        self.days_log.save()
+        result = self.render_template_tag(self.days_log, 'happenings', context={'greeting': 'hello'})
+        self.assertIn('hello', result)

--- a/scribbler/tests/test_views.py
+++ b/scribbler/tests/test_views.py
@@ -7,6 +7,8 @@ from unittest import skipIf
 
 from django.contrib.auth.models import Permission, User
 from django.contrib.contenttypes.models import ContentType
+from django.template.context import RequestContext
+from django.test.client import RequestFactory
 from django.urls import reverse
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.test import override_settings
@@ -21,6 +23,46 @@ from selenium.webdriver.support import expected_conditions as EC
 
 from . import DaysLog
 from .base import ScribblerDataTestCase, Scribble
+from scribbler.views import build_scribble_context
+
+
+class BuildScribbleContextTestCase(ScribblerDataTestCase):
+    "Unit tests for build_scribble_context."
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.scribble = self.create_scribble()
+
+    def test_default_context_contains_scribble(self):
+        "With no context given, result contains the scribble."
+        result = build_scribble_context(self.scribble)
+        self.assertEqual(result['scribble'], self.scribble)
+
+    def test_dict_context_values_preserved(self):
+        "Plain dict context values are available in the result."
+        result = build_scribble_context(self.scribble, {'foo': 'bar'})
+        self.assertEqual(result['foo'], 'bar')
+        self.assertEqual(result['scribble'], self.scribble)
+
+    def test_dict_context_not_mutated(self):
+        "The original dict context is not modified."
+        ctx = {'foo': 'bar'}
+        build_scribble_context(self.scribble, ctx)
+        self.assertNotIn('scribble', ctx)
+
+    def test_request_context_flattened(self):
+        "RequestContext is flattened so its variables are available in the result."
+        request = self.factory.get('/')
+        ctx = RequestContext(request, {'foo': 'bar'})
+        result = build_scribble_context(self.scribble, ctx)
+        self.assertEqual(result['foo'], 'bar')
+        self.assertEqual(result['scribble'], self.scribble)
+
+    def test_scribble_overrides_context(self):
+        "The scribble key always reflects the passed scribble, even if context has one."
+        other_scribble = self.create_scribble()
+        result = build_scribble_context(self.scribble, {'scribble': other_scribble})
+        self.assertEqual(result['scribble'], self.scribble)
 
 
 @override_settings(ROOT_URLCONF='scribbler.tests.urls')

--- a/scribbler/views.py
+++ b/scribbler/views.py
@@ -14,12 +14,16 @@ from .models import Scribble
 from .utils import get_variables
 
 
-def build_scribble_context(scribble):
+def build_scribble_context(scribble, context={}):
     "Create context for rendering a scribble or scribble preview."
-    context = {
-        'scribble': scribble,
-    }
+    if context.__class__.__name__ == 'RequestContext':
+        context = context.flatten()
+    else:
+        context = context.copy()
 
+    context.update({
+        'scribble': scribble,
+    })
     return context
 
 

--- a/scribbler/views.py
+++ b/scribbler/views.py
@@ -14,9 +14,11 @@ from .models import Scribble
 from .utils import get_variables
 
 
-def build_scribble_context(scribble, context={}):
+def build_scribble_context(scribble, context=None):
     "Create context for rendering a scribble or scribble preview."
-    if context.__class__.__name__ == 'RequestContext':
+    if context is None:
+        context = {}
+    elif context.__class__.__name__ == 'RequestContext':
         context = context.flatten()
     else:
         context = context.copy()


### PR DESCRIPTION
New take on #115.

I rebased the code to the current `master` and fixed RequestContext problem with new Django.
I also addressed the notice about modifying context.

I tested this and the preview works for me fine.
It has blank context, so the variables are blank, but I don't expect them to work in preview and I don't consider it to be a problem. It is still much better than not being able to use variables at all.

The only time the preview didn't work was when I had unclosed `<div>` tags in the scribble - then the preview disappeared completely. But that is whole another issue.